### PR TITLE
fix: handle properly StringCompareCondition.startsWith

### DIFF
--- a/src/main/java/io/gravitee/alert/api/condition/StringCompareCondition.java
+++ b/src/main/java/io/gravitee/alert/api/condition/StringCompareCondition.java
@@ -86,8 +86,8 @@ public class StringCompareCondition extends AbstractCondition implements Filter 
         return contains(property, property2, false);
     }
 
-    public static FilterBuilder contains(String property, String property2, boolean ignoreCase) {
-        return new FilterBuilder(property, Operator.CONTAINS, property2, ignoreCase);
+    public static FilterBuilder contains(String property, String pattern, boolean ignoreCase) {
+        return new FilterBuilder(property, Operator.CONTAINS, pattern, ignoreCase);
     }
 
     public static FilterBuilder matches(String property, String pattern) {
@@ -98,12 +98,12 @@ public class StringCompareCondition extends AbstractCondition implements Filter 
         return new FilterBuilder(property, Operator.MATCHES, pattern, ignoreCase);
     }
 
-    public static StringCondition.FilterBuilder startsWith(String property, String pattern) {
+    public static FilterBuilder startsWith(String property, String pattern) {
         return startsWith(property, pattern, false);
     }
 
-    public static StringCondition.FilterBuilder startsWith(String property, String pattern, boolean ignoreCase) {
-        return new StringCondition.FilterBuilder(property, StringCondition.Operator.STARTS_WITH, pattern, ignoreCase);
+    public static FilterBuilder startsWith(String property, String pattern, boolean ignoreCase) {
+        return new FilterBuilder(property, Operator.STARTS_WITH, pattern, ignoreCase);
     }
 
     public static class FilterBuilder {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-alert-engine/issues/369

**Description**

This PR fixes the StringCompareCondition.startsWith not returning the correct builder
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.1-issues-369-notification-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/alert/gravitee-alert-api/1.9.1-issues-369-notification-message-SNAPSHOT/gravitee-alert-api-1.9.1-issues-369-notification-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
