### PR TITLE
fix: relaxed time dampening set as strict time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.2</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.alert</groupId>
@@ -34,9 +34,22 @@
     <name>Gravitee.io - Alert - API</name>
 
     <properties>
-        <gravitee-common.version>1.22.3</gravitee-common.version>
+        <gravitee-common.version>2.0.0</gravitee-common.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
+        <gravitee-bom.version>3.0.0</gravitee-bom.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -55,7 +68,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <!-- Test scope -->
@@ -71,7 +83,7 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>0.18</version>
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.6.1</prettierJavaVersion>

--- a/src/main/java/io/gravitee/alert/api/trigger/Dampening.java
+++ b/src/main/java/io/gravitee/alert/api/trigger/Dampening.java
@@ -81,7 +81,7 @@ public class Dampening implements Serializable {
     }
 
     public static Dampening relaxedTime(int trueEvaluations, long duration) {
-        return new Dampening(Mode.STRICT_TIME, trueEvaluations, null, duration);
+        return new Dampening(Mode.RELAXED_TIME, trueEvaluations, null, duration);
     }
 
     public Mode getMode() {


### PR DESCRIPTION
**Description**

This PR fixes the dampening relaxed time behaviour
It also upgrades a few parent dependencies
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-AE-33-dampening-relaxed-time-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/alert/gravitee-alert-api/2.0.0-AE-33-dampening-relaxed-time-SNAPSHOT/gravitee-alert-api-2.0.0-AE-33-dampening-relaxed-time-SNAPSHOT.zip)
  <!-- Version placeholder end -->
