### PR TITLE
fix: pass through createdAt and updatedAt to alert engine

### DIFF
--- a/src/main/java/io/gravitee/alert/api/trigger/Trigger.java
+++ b/src/main/java/io/gravitee/alert/api/trigger/Trigger.java
@@ -53,6 +53,12 @@ public class Trigger implements Serializable {
     private List<Filter> filters;
     private List<Period> notificationPeriods;
 
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
     @JsonCreator
     protected Trigger(
         @JsonProperty(value = "id", required = true) String id,
@@ -171,6 +177,22 @@ public class Trigger implements Serializable {
         this.notificationPeriods = notificationPeriods;
     }
 
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -210,6 +232,10 @@ public class Trigger implements Serializable {
             filters +
             ", enabled=" +
             enabled +
+            ", createdAt=" +
+            createdAt +
+            ", updatedAt=" +
+            updatedAt +
             '}'
         );
     }
@@ -257,6 +283,8 @@ public class Trigger implements Serializable {
         private List<Period> notificationPeriods = new ArrayList<>();
         private boolean enabled = true;
         private Dampening dampening;
+        private Date createdAt;
+        private Date updatedAt;
 
         private Builder(String source) {
             this.source = source;
@@ -352,6 +380,16 @@ public class Trigger implements Serializable {
             return this;
         }
 
+        public Trigger.Builder createdAt(Date createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Trigger.Builder updatedAt(Date updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
         public Trigger build() {
             final Trigger trigger = new Trigger(
                 (id == null) ? UUID.random().toString() : id,
@@ -366,6 +404,8 @@ public class Trigger implements Serializable {
             trigger.setNotifications(notifications);
             trigger.setEnabled(enabled);
             trigger.setMetadata(metadata);
+            trigger.setCreatedAt(createdAt);
+            trigger.setUpdatedAt(updatedAt);
 
             if (conditions == null || conditions.isEmpty()) {
                 throw new IllegalStateException("A trigger need, at least, one condition defined");

--- a/src/test/java/io/gravitee/alert/api/trigger/TriggerTest.java
+++ b/src/test/java/io/gravitee/alert/api/trigger/TriggerTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -262,5 +263,48 @@ public class TriggerTest {
             .build();
 
         assertFalse(trigger.canNotify(now.toEpochSecond(ZoneOffset.UTC) * 1000));
+    }
+
+    @Test
+    public void shouldExportToJson_withCreatedAtAndUpdatedAt() throws IOException {
+        Date createdAt = new Date(1234567890000L);
+        Date updatedAt = new Date(1234567900000L);
+
+        Trigger trigger = Trigger
+            .on("my-source")
+            .name("shouldExportToJson_withCreatedAtAndUpdatedAt")
+            .condition(StringCondition.equals("a-field", "a-value").build())
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+
+        String json = mapper.writeValueAsString(trigger);
+
+        Assertions.assertNotNull(json);
+
+        Trigger trigger2 = mapper.readValue(json, Trigger.class);
+
+        Assertions.assertEquals(trigger, trigger2);
+        Assertions.assertEquals(createdAt, trigger2.getCreatedAt());
+        Assertions.assertEquals(updatedAt, trigger2.getUpdatedAt());
+    }
+
+    @Test
+    public void shouldExportToJson_withNullTimestamps() throws IOException {
+        Trigger trigger = Trigger
+            .on("my-source")
+            .name("shouldExportToJson_withNullTimestamps")
+            .condition(StringCondition.equals("a-field", "a-value").build())
+            .build();
+
+        String json = mapper.writeValueAsString(trigger);
+
+        Assertions.assertNotNull(json);
+
+        Trigger trigger2 = mapper.readValue(json, Trigger.class);
+
+        Assertions.assertEquals(trigger, trigger2);
+        Assertions.assertNull(trigger2.getCreatedAt());
+        Assertions.assertNull(trigger2.getUpdatedAt());
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Trigger now declares createdAt and updatedAt directly. 
APIM must remove these fields from superclass before upgrading.

**Issue**

https://gravitee.atlassian.net/browse/CJ-4041

**Description**

Add `updatedAt` and `createdAt` fields to trigger. 

These are moved from apim class which extends trigger - `AlertTriggerEntity`. They are moved so that they are included and sent to alert engine from apim. This is so they can be used to calculate alert schedule and keep the schedule consistent. This will be implemented in alert engine with https://gravitee.atlassian.net/browse/CJ-4040. 

The reason I made it a breaking change is that apim has to remove these fields from AlertTriggerEntity when using this version as otherwise will fail to compile as they would be duplicated. APIM PR here - https://github.com/gravitee-io/gravitee-api-management/pull/15264

I think only `updatedAt` is required but maybe `createdAt` could be useful so I just included both in case. 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-cj-4041-move-timestamps-to-base-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/alert/gravitee-alert-api/3.0.0-cj-4041-move-timestamps-to-base-SNAPSHOT/gravitee-alert-api-3.0.0-cj-4041-move-timestamps-to-base-SNAPSHOT.zip)
  <!-- Version placeholder end -->
